### PR TITLE
Fix minor typos and rewording.

### DIFF
--- a/pages/docs/manual/latest/introduction.mdx
+++ b/pages/docs/manual/latest/introduction.mdx
@@ -22,7 +22,7 @@ ReScript's type system alone offers three major benefits to make your programs m
 
 - **Sound type system**. "Sound" here means that the types _guarantee_ that they are what they are, not just 90% of the time. Once a ReScript project compiles, there are no runtime type errors. \*
 - **Strong type inference**. Almost the entirety of the language can be inferred. You don't have to tediously write all the types manually. Feel free to still type out some parts for readability!
-- **Expressive type features**. With well-thought-out features like [variants](variant.md)[pattern matching](pattern-matching-destructuring.md) and [modules](module.md), the types guide you through your iteration process and don't block you from expressing what you need.
+- **Expressive type features**. With well-thought-out features like [variants](variant.md), [pattern matching](pattern-matching-destructuring.md), and [modules](module.md), the types guide you through your iteration process and don't block you from expressing what you need.
 
 The combination of these highlights, along with other type system features, unlocks new workflow possibilities and is something existing gradual typing solutions for JavaScript don't offer.
 

--- a/pages/docs/manual/latest/null-undefined-option.mdx
+++ b/pages/docs/manual/latest/null-undefined-option.mdx
@@ -1,6 +1,6 @@
 # Null, Undefined and Option
 
-ReScript itself doesn't have the notion of `null` or `undefined`. This is a _great_ thing, as it wipes out an entire category of bugs. No more `undefined is not a function`, and `cannot access foo of undefined`!
+ReScript itself doesn't have the notion of `null` or `undefined`. This is a _great_ thing, as it wipes out an entire category of bugs. No more `undefined is not a function`, and `cannot access someAttribute of undefined`!
 
 However, the **concept** of a potentially nonexistent value is still useful, and safely exists in our language.
 

--- a/pages/docs/manual/latest/overview.mdx
+++ b/pages/docs/manual/latest/overview.mdx
@@ -220,7 +220,7 @@ Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&
 Shallow and deep Equality       | `===`, `==`                          | `===`, `==`
 List (disrecommended)           | `list{1, 2, 3}`                      | `[1, [2, [3, 0]]]`
 List Prepend                    | `list{a1, a2, ...theRest}`           | `[a1, [a2, theRest]]`
-Array                           | `[1, 2, 3]                           | `[1, 2, 3]`
+Array                           | `[1, 2, 3]`                          | `[1, 2, 3]`
 Record                          | `type t = {b: int}; let a = {b: 10}` | `var a = {b: 10}`
 Multiline Comment               | `/* Comment here */`                 | Not in output
 Single line Comment             | `// Comment here`                    | Not in output

--- a/pages/docs/manual/latest/primitive-types.mdx
+++ b/pages/docs/manual/latest/primitive-types.mdx
@@ -75,7 +75,7 @@ ReScript has a type for a string with a single letter:
 let firstLetterOfAlphabet = 'a'
 ```
 
-**Note**: Char doesn't support Unicode or UTF-8 and is therefore disrecommended.
+**Note**: Char doesn't support Unicode or UTF-8 and is therefore not recommended.
 
 To convert a String to a Char, use `"a".[0]`. To convert a Char to a String, use `String.make(1, 'a')`.
 
@@ -106,7 +106,7 @@ ReScript's `true/false` compiles into a JavaScript `true/false`.
 
 ## Integers
 
-32-bits, truncated when necessary. We provides the usual operations on them: `+`, `-`, `*`, `/`, etc. See [Js.Int](/apis/latest/js/int) for helper functions.
+32-bits, truncated when necessary. We provide the usual operations on them: `+`, `-`, `*`, `/`, etc. See [Js.Int](/apis/latest/js/int) for helper functions.
 
 **Careful when you bind to JavaScript numbers**! Long ones might be truncated. Bind JS number (especially Dates) as **float** instead.
 

--- a/pages/docs/manual/latest/type.mdx
+++ b/pages/docs/manual/latest/type.mdx
@@ -1,7 +1,7 @@
 # Type
 
 Types are the highlight of ReScript! They are:
-- **Strong**. A type can't change into another type. In JavaScript, your variable's type might change when the code runs (aka at runtime). E.g. a `number` variable might change into a `string` sometime. This is an anti-feature; it makes the code much harder to read during writing.
+- **Strong**. A type can't change into another type. In JavaScript, your variable's type might change when the code runs (aka at runtime). E.g. a `number` variable might change into a `string` sometime. This is an anti-feature; it makes the code much harder to understand when reading or debugging.
 - **Static**. ReScript types are erased after compilation and don't exist at runtime. Never worry about your types dragging down performance. You don't need type info during runtime; we report all the information (especially all the type errors) during compile time. Catch the bugs earlier!
 - **Sound**. This is our biggest differentiator versus many other typed languages that compile to JavaScript. Our type system is guaranteed to **never** be wrong. Most type systems make a guess at the type of a value and show you a type in your editor that's sometime incorrect. We don't do that. We believe that a type system that is sometime incorrect can end up being dangerous due to expectation mismatches.
 - **Fast**. Many developers underestimate how much of their project's build time goes into type checking. Our type checker is one of the fastest around.

--- a/pages/docs/manual/latest/variant.mdx
+++ b/pages/docs/manual/latest/variant.mdx
@@ -112,7 +112,7 @@ let betterDraw = (animal) =>
   }
 ```
 
-You could definitely do that, but there are better ways! For example, simply two `external`s that both compile to the same JS call:
+You could definitely do that, but there are better ways! For example, define two `external`s that both compile to the same JS call:
 
 ```res
 @bs.module("myLibrary") external drawFloat: float => unit = "draw"
@@ -123,7 +123,7 @@ ReScript also provides [a few other ways](bind-to-js-function.md#modeling-polymo
 
 ### Variant Types Are Found By Field Name
 
-Please refer to this [record section](record#record-types-are-found-by-field-name). Variants are the same: a function can't accept an arbitrary constructor shared by two different variants. Again, such feature exists, it's called a polymorphic variant. We'll talk about this in the future =).
+Please refer to this [record section](record#record-types-are-found-by-field-name). Variants are the same: a function can't accept an arbitrary constructor shared by two different variants. Again, such feature exists; it's called a polymorphic variant. We'll talk about this in the future =).
 
 ## Design Decisions
 


### PR DESCRIPTION
Fixes minor typographical errors. Replace a reference to `foo` with a more meaningful name. Eliminate the word “simply“ (not only a word to avoid in technical writing, in the instance where I replaced it, it doesn’t fit).