### PR TITLE
Fix #38: Typo in let binding docs - rogue ';'

### DIFF
--- a/pages/docs/manual/latest/let-binding.mdx
+++ b/pages/docs/manual/latest/let-binding.mdx
@@ -55,7 +55,7 @@ ReScript's `if`, `while` and functions all use the same block scoping mecanism. 
 if displayGreeting {
   let message = "Enjoying the docs so far?"
   Js.log(message)
-};
+}
 // `message` not accessible here!
 ```
 ```js

--- a/pages/docs/manual/v8.0.0/let-binding.mdx
+++ b/pages/docs/manual/v8.0.0/let-binding.mdx
@@ -55,7 +55,7 @@ ReScript's `if`, `while` and functions all use the same block scoping mecanism. 
 if (displayGreeting) {
   let message = "Enjoying the docs so far?";
   Js.log(message);
-};
+}
 // `message` not accessible here!
 ```
 ```js


### PR DESCRIPTION
I believe that the semicolon in the design decisions section of the let binding doc is not necessary, so here is a PR to drop it.

If I'm wrong, let me know!