### PR TITLE
Small mention about disjunctive patterns 

### DIFF
--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -583,6 +583,8 @@ Do not abuse the wildcard `_` too much. This prevents the compiler from giving y
 If you're about to use a wildcard when matching on a large but finite set of possibilities because you have many possibilities that return the same thing, consider reaching for disjunctive patterns instead. That is, you can replace:
 
 ```res example
+type T = A | B | C | D | E
+let v = C
 switch v {
 | A => handleTheCaseICareAbout()
 | B => handleTheRest()
@@ -595,6 +597,8 @@ switch v {
 with:
 
 ```res example
+type T = A | B | C | D | E
+let v = C
 switch v {
 | A => handleTheCaseICareAbout()
 | B

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -580,6 +580,31 @@ Here are some advices.
 
 Do not abuse the wildcard `_` too much. This prevents the compiler from giving you better exhaustiveness check, which would be especially important after a refactoring where you add a new case to a variant. Try only using `_` against infinite possibilities, e.g. string, int, etc.
 
+If you're about to use a wildcard when matching on a large but finite set of possibilities because you have many possibilities that return the same thing, consider reaching for disjunctive patterns instead. That is, you can replace:
+
+```res example
+switch v {
+| A => handleTheCaseICareAbout()
+| B => handleTheRest()
+| C => handleTheRest()
+| D => handleTheRest()
+| E => handleTheRest()
+}
+```
+
+with:
+
+```res example
+switch v {
+| A => handleTheCaseICareAbout()
+| B
+| C
+| D
+| E => handleTheRest()
+}
+```
+This still requires a bit more work than a wildcard, but we promise it'll be worth it.
+
 Use `when` clause sparingly.
 
 **Flatten your pattern-match whenever you can**. This is a real bug remover. Here's a series of examples, from worst to best:

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -580,17 +580,14 @@ Here are some advices.
 
 Do not abuse the wildcard `_` too much. This prevents the compiler from giving you better exhaustiveness check, which would be especially important after a refactoring where you add a new case to a variant. Try only using `_` against infinite possibilities, e.g. string, int, etc.
 
-If you're about to use a wildcard when matching on a large but finite set of possibilities because you have many possibilities that return the same thing, consider reaching for disjunctive patterns instead. That is, you can replace:
+Sometimes you want to pattern-match on a large but finite set of possibilities and many possibilities map to the expression. In these cases, wildcards can seem tempting because they reduce code duplication, but there's another option, often termed disjunctive patterns, that allows you to map multiple patterns to a single expression. That is, you can replace:
 
 ```res example
 type t = A | B | C | D | E
 let v = C
 switch v {
 | A => 1
-| B => 2
-| C => 2
-| D => 2
-| E => 2
+| _ => 2
 }
 ```
 
@@ -601,13 +598,21 @@ type t = A | B | C | D | E
 let v = C
 switch v {
 | A => 1
-| B
-| C
-| D
-| E => 2
+| B | C | D | E => 2
 }
 ```
-This still requires a bit more work than a wildcard, but we promise it'll be worth it.
+
+This still requires a bit more work than a wildcard, but it has the advantage of ensuring the compiler can enforce exhaustiveness, unlike a wildcard based solution. Additionally, unlike wildcards, you can easily refactor your code to have multiple pattern sets, like so:
+
+```res example
+type t = A | B | C | D | E
+let v = C
+switch v {
+| A => 1
+| B | C => 2
+| D | E => 3
+}
+```
 
 Use `when` clause sparingly.
 

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -572,15 +572,9 @@ if (myNullableValue !== undefined) {
 
 If you don't handle the `None` case, the compiler warns. No more `undefined` bugs in your code!
 
-## Conclusion & Tips & Tricks
+### Match multiple cases to one expression
 
-Hopefully you can see how pattern matching is a game changer for writing correct code, through the concise destructuring syntax, the proper conditions handling of `switch`, and the static exhaustiveness check.
-
-Here are some advices.
-
-Do not abuse the wildcard `_` too much. This prevents the compiler from giving you better exhaustiveness check, which would be especially important after a refactoring where you add a new case to a variant. Try only using `_` against infinite possibilities, e.g. string, int, etc.
-
-Sometimes you want to pattern-match on a large but finite set of possibilities and many possibilities map to the expression. In these cases, wildcards can seem tempting because they reduce code duplication, but there's another option, often termed disjunctive patterns, that allows you to map multiple patterns to a single expression. That is, you can replace:
+Now, sometimes you may want to pattern-match on large but finite sets of possibilities where many possibilities map to the same expression. In these cases, wildcards can seem tempting because they reduce code duplication, but there's another option, often termed disjunctive patterns, that allow you to map multiple patterns to a single expression. That is, you can replace:
 
 ```res example
 type t = A | B | C | D | E
@@ -613,6 +607,14 @@ switch v {
 | D | E => 3
 }
 ```
+
+## Conclusion & Tips & Tricks
+
+Hopefully you can see how pattern matching is a game changer for writing correct code, through the concise destructuring syntax, the proper conditions handling of `switch`, and the static exhaustiveness check.
+
+Here are some advices.
+
+Do not abuse the wildcard `_` too much. This prevents the compiler from giving you better exhaustiveness check, which would be especially important after a refactoring where you add a new case to a variant. Try only using `_` against infinite possibilities, e.g. string, int, etc.
 
 Use `when` clause sparingly.
 

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -583,28 +583,28 @@ Do not abuse the wildcard `_` too much. This prevents the compiler from giving y
 If you're about to use a wildcard when matching on a large but finite set of possibilities because you have many possibilities that return the same thing, consider reaching for disjunctive patterns instead. That is, you can replace:
 
 ```res example
-type T = A | B | C | D | E
+type t = A | B | C | D | E
 let v = C
 switch v {
-| A => handleTheCaseICareAbout()
-| B => handleTheRest()
-| C => handleTheRest()
-| D => handleTheRest()
-| E => handleTheRest()
+| A => 1
+| B => 2
+| C => 2
+| D => 2
+| E => 2
 }
 ```
 
 with:
 
 ```res example
-type T = A | B | C | D | E
+type t = A | B | C | D | E
 let v = C
 switch v {
-| A => handleTheCaseICareAbout()
+| A => 1
 | B
 | C
 | D
-| E => handleTheRest()
+| E => 2
 }
 ```
 This still requires a bit more work than a wildcard, but we promise it'll be worth it.


### PR DESCRIPTION
Disjunctive patterns are super valuable when you (rightly) don't want to use a wildcard, but have a lot of cases that match to the same thing. I think they should at least be mentioned in the docs even if they may not warrant a whole sub-section.

Because of the tiny size of this change, I just went ahead and opened a PR since it took about the same amount of work as opening an issue on the topic. I hope that's okay.