### PR TITLE
Add missing documentation for setItem

### DIFF
--- a/pages/docs/manual/latest/api/dom/storage.mdx
+++ b/pages/docs/manual/latest/api/dom/storage.mdx
@@ -12,6 +12,12 @@ type t
 external getItem: (string, t) => option<string> = "getItem"
 ```
 
+## setItem
+
+```res sig
+external setItem: (string, string, t) => unit = "setItem"
+```
+
 ## removeItem
 
 ```res sig

--- a/pages/docs/manual/latest/api/dom/storage2.mdx
+++ b/pages/docs/manual/latest/api/dom/storage2.mdx
@@ -2,11 +2,9 @@
 
 <Intro>
 
-
 The same as [Dom.Storage](./storage2), but with `t` on first argument position for proper `->` usage.
 
 </Intro>
-
 
 ## t
 

--- a/pages/docs/manual/latest/api/dom/storage2.mdx
+++ b/pages/docs/manual/latest/api/dom/storage2.mdx
@@ -2,9 +2,11 @@
 
 <Intro>
 
+
 The same as [Dom.Storage](./storage2), but with `t` on first argument position for proper `->` usage.
 
 </Intro>
+
 
 ## t
 
@@ -16,6 +18,12 @@ type t
 
 ```res sig
 external getItem: (t, string) => option<string> = "getItem"
+```
+
+## setItem
+
+```res sig
+external setItem: (t, string, string) => unit = "setItem"
 ```
 
 ## removeItem

--- a/pages/docs/manual/v8.0.0/api/dom/storage.mdx
+++ b/pages/docs/manual/v8.0.0/api/dom/storage.mdx
@@ -12,6 +12,12 @@ type t
 external getItem: (string, t) => option<string> = "getItem"
 ```
 
+## setItem
+
+```res sig
+external setItem: (string, string, t) => unit = "setItem"
+```
+
 ## removeItem
 
 ```re sig

--- a/pages/docs/manual/v8.0.0/api/dom/storage.mdx
+++ b/pages/docs/manual/v8.0.0/api/dom/storage.mdx
@@ -14,7 +14,7 @@ external getItem: (string, t) => option<string> = "getItem"
 
 ## setItem
 
-```res sig
+```re sig
 external setItem: (string, string, t) => unit = "setItem"
 ```
 

--- a/pages/docs/manual/v8.0.0/api/dom/storage2.mdx
+++ b/pages/docs/manual/v8.0.0/api/dom/storage2.mdx
@@ -20,7 +20,7 @@ external getItem: (t, string) => option(string) = "getItem"
 
 ## setItem
 
-```res sig
+```re sig
 external setItem: (t, string, string) => unit = "setItem"
 ```
 

--- a/pages/docs/manual/v8.0.0/api/dom/storage2.mdx
+++ b/pages/docs/manual/v8.0.0/api/dom/storage2.mdx
@@ -18,6 +18,12 @@ type t
 external getItem: (t, string) => option(string) = "getItem"
 ```
 
+## setItem
+
+```res sig
+external setItem: (t, string, string) => unit = "setItem"
+```
+
 ## removeItem
 
 ```re sig


### PR DESCRIPTION
The `setItem` on `Dom.Storage` and `Dom.storage2` were missing from the documentation.