### PR TITLE
Update jsx documentation

### DIFF
--- a/pages/docs/manual/latest/jsx.mdx
+++ b/pages/docs/manual/latest/jsx.mdx
@@ -227,7 +227,7 @@ React.createElement(
 
 "Punning" refers to the syntax shorthand for when a label and a value are the same. For example, in JavaScript, instead of doing `return {name: name}`, you can do `return {name}`.
 
-Reason JSX supports punning. `<input checked />` is just a shorthand for `<input checked=checked />`. The formatter will help you format to the latter whenever possible. This is convenient in the cases where there are lots of props to pass down:
+Reason JSX supports punning. `<input checked />` is just a shorthand for `<input checked=checked />`. The formatter will help you format to the punned syntax whenever possible. This is convenient in the cases where there are lots of props to pass down:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 

--- a/pages/docs/manual/v8.0.0/jsx.mdx
+++ b/pages/docs/manual/v8.0.0/jsx.mdx
@@ -263,7 +263,7 @@ React.createElement(
 
 "Punning" refers to the syntax shorthand for when a label and a value are the same. For example, in JavaScript, instead of doing `return {name: name}`, you can do `return {name}`.
 
-Reason JSX supports punning. `<input checked />` is just a shorthand for `<input checked=checked />`. The formatter will help you format to the latter whenever possible. This is convenient in the cases where there are lots of props to pass down:
+Reason JSX supports punning. `<input checked />` is just a shorthand for `<input checked=checked />`. The formatter will help you format to the punned syntax whenever possible. This is convenient in the cases where there are lots of props to pass down:
 
 <CodeTab labels={["Reason (Old Syntax)", "ML (Older Syntax)", "JS Output"]}>
 


### PR DESCRIPTION
The text implies that the formatter will prefer the punned version of code whenever possible. However, given the structure of the sentence that is the former option, not the latter. To avoid future ambiguity it seemed clearer to refer directly to "the punned syntax" rather than referencing positionally.