### PR TITLE
Add section to easily migrate an entire folder of code into "Migrate from BuckleScript/Reason" page

### DIFF
--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -16,8 +16,8 @@ ReScript is a rebranding and cleanup of BuckleScript (since `v8.2.0`) & Reason (
 There are lots of exciting improvements in the new syntax (features, speed, error messages, etc.). The upgrade is trivial, backward-compatible and can be done on a per-file basis:
 
 - Upgrade your project to `bs-platform 8.2.0` or later.
-- `node_modules/.bin/bsc -format MyFile.re > MyFile.res`
-- If your new `MyFile.res` looks good, you can delete (or move) `MyFile.re` (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile`
+- `node_modules/.bin/bsc -format MyFile.re > MyFile.res`.
+- If your new `MyFile.res` looks good, you can delete (or move) `MyFile.re` (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile`).
 
 **That's it**! `MyFile.re` could be any `.re`, `.rei`, `.ml` and `.mli` file.
 

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -19,7 +19,7 @@ There are lots of exciting improvements in the new syntax (features, speed, erro
 - Choose a file to convert, for example `MyFile.re`
 - Compile your project and keep the generated JavaScript file around (probably `MyFile.bs.js` but might depend on your `bsconfig.json` config).
 - Run `node_modules/.bin/bsc -format MyFile.re > MyFile.res`.
-- If your new `MyFile.res` looks good, you can delete (or move/rename) `MyFile.re` before compiling again your project (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile` because 2 files with the same module (file basename) name cannot coexist in your project).
+- If your new `MyFile.res` looks good, you can delete (or move/rename) `MyFile.re` before compiling again your project (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile` because 2 files with the same module name (file basename)  cannot coexist in your project).
 - Last thing you can do to ensure conversion is correct: build your project with the new `MyFile.res` file to compare the newly generated JavaScript file with the old one. You should get almost identical generated JavaScript code.
 
 **That's it**! `MyFile.re` could be any `.re`, `.rei`, `.ml` and `.mli` file.

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -16,8 +16,10 @@ ReScript is a rebranding and cleanup of BuckleScript (since `v8.2.0`) & Reason (
 There are lots of exciting improvements in the new syntax (features, speed, error messages, etc.). The upgrade is trivial, backward-compatible and can be done on a per-file basis:
 
 - Upgrade your project to `bs-platform 8.2.0` or later.
-- `node_modules/.bin/bsc -format MyFile.re > MyFile.res`.
-- If your new `MyFile.res` looks good, you can delete (or move) `MyFile.re` (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile`).
+- Compile your project and keep the generated JavaScript file around (probably `MyFile.bs.js` but might depend on your `bsconfig.json` config).
+- Run `node_modules/.bin/bsc -format MyFile.re > MyFile.res`.
+- If your new `MyFile.res` looks good, you can delete (or move/rename) `MyFile.re` before compiling again your project (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile` because 2 files with the same module (file basename) name cannot coexist in your project).
+- Last thing you can do to ensure conversion is correct: build your project with the new `MyFile.res` file to compare the newly generated JavaScript file with the old one. You should get almost identical generated JavaScript code.
 
 **That's it**! `MyFile.re` could be any `.re`, `.rei`, `.ml` and `.mli` file.
 
@@ -33,7 +35,8 @@ That being said, for small codebases or some tiny folders that are safely versio
 for f in your-folder/**/*.re; do; node_modules/.bin/bsc -format $f > ${f%.re}.res && rm $f; done;
 ```
 
-This command loops on the `.re` files from the `your-folder` folder, converts them with a proper `.res` extension, and asks you if you want to remove the previous file (check the newly created `.res` file first). If you are confident enough, you can add `-f` option to the `rm` command.
+This command loops on the `.re` files from the `your-folder` folder, converts them with a proper `.res` extension, and asks you if you want to remove the previous file (check the newly created `.res` file first and refer to instructions above to follow the check to do on your generated JavaScript).
+If you are confident enough, you can add `-f` option to the `rm` command to avoid all checks. This will convert your entire folder without any confirmations.
 
 ## Difference With Old Reason
 

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -25,7 +25,7 @@ Enjoy the improved experience!
 
 ### Upgrade an Entire Folder
 
-Please use this with caution. Migrating an entire codebase at once is an uncessary risk.
+Please use this with caution. Migrating an entire codebase at once is an unnecessary risk.
 It is recommended to migrate small portion of code to ensure correctness.
 That being said, for small codebases or some tiny folders that are safely versionned, you can try the following:
 
@@ -33,7 +33,7 @@ That being said, for small codebases or some tiny folders that are safely versio
 for f in your-folder/**/*.re; do; node_modules/.bin/bsc -format $f > ${f%.re}.res && rm $f; done;
 ```
 
-This command loop on the `.re` files from the `your-folder` folder, convert them with a proper `.res` extension, and ask you if you want to remove the previous file (check the newly created `.res` file first). If you are confident enough, you can add `-f` option to the `rm` command.
+This command loops on the `.re` files from the `your-folder` folder, converts them with a proper `.res` extension, and asks you if you want to remove the previous file (check the newly created `.res` file first). If you are confident enough, you can add `-f` option to the `rm` command.
 
 ## Difference With Old Reason
 

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -30,7 +30,7 @@ Enjoy the improved experience!
 
 Please use this with caution. Migrating an entire codebase at once is an unnecessary risk.
 It is recommended to migrate small portion of code to ensure correctness.
-That being said, for small codebases or some tiny folders that are safely versionned, you can try the following:
+That being said, for small codebases or some tiny folders that are safely versioned, you can try the following:
 
 ```console
 for f in your-folder/**/*.re; do; node_modules/.bin/bsc -format $f > ${f%.re}.res && rm $f; done;

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -16,6 +16,7 @@ ReScript is a rebranding and cleanup of BuckleScript (since `v8.2.0`) & Reason (
 There are lots of exciting improvements in the new syntax (features, speed, error messages, etc.). The upgrade is trivial, backward-compatible and can be done on a per-file basis:
 
 - Upgrade your project to `bs-platform 8.2.0` or later.
+- Choose a file to convert, for example `MyFile.re`
 - Compile your project and keep the generated JavaScript file around (probably `MyFile.bs.js` but might depend on your `bsconfig.json` config).
 - Run `node_modules/.bin/bsc -format MyFile.re > MyFile.res`.
 - If your new `MyFile.res` looks good, you can delete (or move/rename) `MyFile.re` before compiling again your project (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile` because 2 files with the same module (file basename) name cannot coexist in your project).

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -17,10 +17,23 @@ There are lots of exciting improvements in the new syntax (features, speed, erro
 
 - Upgrade your project to `bs-platform 8.2.0` or later.
 - `node_modules/.bin/bsc -format MyFile.re > MyFile.res`
+- If your new `MyFile.res` looks good, you can delete (or move) `MyFile.re` (otherwise you will have an error `Invalid bsconfig.json implementation and interface have different path names or different cases MyFile vs MyFile`
 
 **That's it**! `MyFile.re` could be any `.re`, `.rei`, `.ml` and `.mli` file.
 
 Enjoy the improved experience!
+
+### Upgrade an Entire Folder
+
+Please use this with caution. Migrating an entire codebase at once is an uncessary risk.
+It is recommended to migrate small portion of code to ensure correctness.
+That being said, for small codebases or some tiny folders that are safely versionned, you can try the following:
+
+```console
+for f in your-folder/**/*.re; do; node_modules/.bin/bsc -format $f > ${f%.re}.res && rm $f; done;
+```
+
+This command loop on the `.re` files from the `your-folder` folder, convert them with a proper `.res` extension, and ask you if you want to remove the previous file (check the newly created `.res` file first). If you are confident enough, you can add `-f` option to the `rm` command.
 
 ## Difference With Old Reason
 


### PR DESCRIPTION
Because I think it's useful (and safe as soon as you have versioned codebase.