### PR TITLE
Remove duplicate % from raw embed

### DIFF
--- a/pages/docs/manual/latest/embed-raw-javascript.mdx
+++ b/pages/docs/manual/latest/embed-raw-javascript.mdx
@@ -13,7 +13,7 @@ First thing first. If you're ever stuck learning ReScript, remember that you can
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-%%raw(`
+%raw(`
 // look ma, regular JavaScript!
 var message = "hello";
 function greet(m) {


### PR DESCRIPTION
It's the first example you see, but it doesn't actually work.
```
13 │ });
  14 │ 
  15 │ wsClient->addEventListener("connecting", %%raw(`console.log`));
  16 │ wsClient->addEventListener("connected", %%raw(`console.log`));
  17 │ wsClient->addEventListener("closed", %%raw(`console.log`));
  
  Did you forget a `)` here?
```

The singular form from other examples works as expected.