### PR TITLE
Add item.id to use as syntax lookup widget slug

### DIFF
--- a/src/components/SyntaxLookupWidget.js
+++ b/src/components/SyntaxLookupWidget.js
@@ -43,6 +43,7 @@ function SyntaxLookupWidget$Category(Props) {
 
 var allItems = [
   {
+    id: "module-decorator",
     keywords: ["@bs.module"],
     name: "@module",
     summary: "This is the `@module` decorator.",
@@ -50,6 +51,7 @@ var allItems = [
     component: Decorator_moduleMdx
   },
   {
+    id: "as-decorator",
     keywords: ["@bs.as"],
     name: "@as",
     summary: "This is the `@as` decorator.",
@@ -57,6 +59,7 @@ var allItems = [
     component: Decorator_asMdx
   },
   {
+    id: "if-else",
     keywords: [
       "if",
       "else",
@@ -68,6 +71,7 @@ var allItems = [
     component: Controlflow_ifelseMdx
   },
   {
+    id: "uncurried-function",
     keywords: ["uncurried"],
     name: "(.) => {}",
     summary: "This is an `uncurried` function.",
@@ -151,7 +155,7 @@ function SyntaxLookupWidget(Props) {
           var anchor = getAnchor(router.asPath);
           if (anchor !== undefined) {
             Belt_Option.forEach(Caml_option.undefined_to_opt(allItems.find(function (item) {
-                          return GithubSlugger.slug(item.name) === anchor;
+                          return GithubSlugger.slug(item.id) === anchor;
                         })), (function (item) {
                     return Curry._1(setState, (function (param) {
                                   return {
@@ -172,13 +176,13 @@ function SyntaxLookupWidget(Props) {
           } else {
             var item = state._0;
             if (match !== undefined) {
-              var slug = GithubSlugger.slug(item.name);
+              var slug = GithubSlugger.slug(item.id);
               if (slug !== match) {
                 Next.Router.replace(router, "syntax-lookup#" + match);
               }
               
             } else {
-              Next.Router.replace(router, "syntax-lookup#" + GithubSlugger.slug(item.name));
+              Next.Router.replace(router, "syntax-lookup#" + GithubSlugger.slug(item.id));
             }
           }
           if (exit === 1) {

--- a/src/components/SyntaxLookupWidget.res
+++ b/src/components/SyntaxLookupWidget.res
@@ -46,6 +46,7 @@ module Category = {
 }
 
 type item = {
+  id: string,
   keywords: array<string>,
   name: string,
   summary: string,
@@ -55,6 +56,7 @@ type item = {
 
 let allItems = [
   {
+    id: "module-decorator",
     keywords: ["@bs.module"],
     name: "@module",
     summary: "This is the `@module` decorator.",
@@ -62,6 +64,7 @@ let allItems = [
     component: decorator_module,
   },
   {
+    id: "as-decorator",
     keywords: ["@bs.as"],
     name: "@as",
     summary: "This is the `@as` decorator.",
@@ -69,6 +72,7 @@ let allItems = [
     component: decorator_as,
   },
   {
+    id: "if-else",
     keywords: ["if", "else", "if else"],
     name: "if / else",
     summary: "This is the `if / else` control flow structure.",
@@ -76,6 +80,7 @@ let allItems = [
     component: controlflow_ifelse,
   },
   {
+    id: "uncurried-function",
     keywords: ["uncurried"],
     name: "(.) => {}",
     summary: "This is an `uncurried` function.",
@@ -152,7 +157,7 @@ let make = () => {
     switch getAnchor(router.asPath) {
     | Some(anchor) =>
       Js.Array2.find(allItems, item =>
-        GithubSlugger.slug(item.name) === anchor
+        GithubSlugger.slug(item.id) === anchor
       )->Belt.Option.forEach(item => {
         setState(_ => ShowDetails(item))
       })
@@ -172,7 +177,7 @@ let make = () => {
   React.useEffect1(() => {
     switch (state, getAnchor(router.asPath)) {
     | (ShowDetails(item), Some(anchor)) =>
-      let slug = GithubSlugger.slug(item.name)
+      let slug = GithubSlugger.slug(item.id)
 
       if slug !== anchor {
         router->Next.Router.replace("syntax-lookup#" ++ anchor)
@@ -180,7 +185,7 @@ let make = () => {
         ()
       }
     | (ShowDetails(item), None) =>
-      router->Next.Router.replace("syntax-lookup#" ++ GithubSlugger.slug(item.name))
+      router->Next.Router.replace("syntax-lookup#" ++ GithubSlugger.slug(item.id))
     | (_, Some(_)) => router->Next.Router.replace("syntax-lookup")
     | _ => ()
     }


### PR DESCRIPTION
Suggestion for https://github.com/reason-association/rescript-lang.org/issues/162

The `GithubSlugger` seems to convert non alphanumeric characters to hyphens.

For example `(.) => {}` is converted to `--`.

Which results the URL `/syntax-lookup#--`

What do you think about introducing an `id` field into the items? This would need to be unique for each item, but would provide a convenient field for converting to a slug.

Which would then enable URLs such as `/syntax-lookup#uncurried-function`