### PR TITLE
Document the @deprecated attribute. Fixes #168

### DIFF
--- a/pages/docs/manual/latest/attribute.mdx
+++ b/pages/docs/manual/latest/attribute.mdx
@@ -45,6 +45,12 @@ type student = {
   age: int,
   @bs.as("aria-label") ariaLabel: string,
 }
+
+@deprecated
+let customDouble = foo => foo * 2
+
+@deprecated("Do the math yourself!")
+let customTriple = foo => foo * 3 
 ```
 ```js
 ```
@@ -55,6 +61,8 @@ type student = {
 2. `@unboxed` annotates the type definition.
 3. `@bs.val` annotates the `external` statement.
 4. `@bs.as("aria-label")` annotates the `ariaLabel` record field.
+5. `@deprecated` annotates the `customDouble` expression. This shows a warning while compiling telling consumers to not rely on this method long-term.
+6. `@deprecated("Outdated")` annotates the `customTriple` expression with a string to describe the reason for deprecation.
 
 ## Extension Point
 

--- a/pages/docs/manual/latest/attribute.mdx
+++ b/pages/docs/manual/latest/attribute.mdx
@@ -49,7 +49,7 @@ type student = {
 @deprecated
 let customDouble = foo => foo * 2
 
-@deprecated("Do the math yourself!")
+@deprecated("Use SomeOther.customTriple instead")
 let customTriple = foo => foo * 3 
 ```
 ```js

--- a/pages/docs/manual/latest/attribute.mdx
+++ b/pages/docs/manual/latest/attribute.mdx
@@ -62,7 +62,7 @@ let customTriple = foo => foo * 3
 3. `@bs.val` annotates the `external` statement.
 4. `@bs.as("aria-label")` annotates the `ariaLabel` record field.
 5. `@deprecated` annotates the `customDouble` expression. This shows a warning while compiling telling consumers to not rely on this method long-term.
-6. `@deprecated("Outdated")` annotates the `customTriple` expression with a string to describe the reason for deprecation.
+6. `@deprecated("Use SomeOther.customTriple instead")` annotates the `customTriple` expression with a string to describe the reason for deprecation.
 
 ## Extension Point
 


### PR DESCRIPTION
Add a few examples for the @deprecated attribute. I've added it to the existing example, but alternatively it could show up as its on section on the attributes page. Fixes #168.