### PR TITLE
Add @uncurry decorator syntax lookup

### DIFF
--- a/misc_docs/syntax/decorator_uncurry.mdx
+++ b/misc_docs/syntax/decorator_uncurry.mdx
@@ -31,4 +31,4 @@ var result = [1, 2, 3].map(function (x) {
 
 ### References
 
-- [Curry & Uncurry](/docs/manual/latest/bind-to-js-function#curry--uncurry)
+- [Use Guaranteed Uncurrying](/docs/manual/latest/bind-to-js-function#solution-use-guaranteed-uncurrying)

--- a/misc_docs/syntax/decorator_uncurry.mdx
+++ b/misc_docs/syntax/decorator_uncurry.mdx
@@ -6,8 +6,8 @@ summary: "This is the `@uncurry` decorator."
 category: "decorators"
 ---
 
-The `@uncurry` decorator allows you to annotate *external* function callback arguments
-so the callbacks may be declared as normal functions `() => { ... }` rather then needing
+The `@uncurry` decorator allows you to annotate **external** function callback argument types
+so when writing the callbacks they may be declared as normal functions `() => { ... }` rather then needing
 the uncurried function syntax `(.) => { ... }`.
 
 ### Example

--- a/misc_docs/syntax/decorator_uncurry.mdx
+++ b/misc_docs/syntax/decorator_uncurry.mdx
@@ -6,11 +6,11 @@ summary: "This is the `@uncurry` decorator."
 category: "decorators"
 ---
 
-The `@uncurry` decorator allows you to annotate **external** function callback argument types
-so when writing the callbacks they may be declared as normal functions `() => { ... }`
-rather than needing the uncurried function syntax `(.) => { ... }`.
+The `@uncurry` decorator can be used to mark any callback argument within an **external** function as an uncurried function without the need for any [explicit uncurried function syntax](/docs/manual/latest/function#uncurried-function) `((.) => { ... })`.
 
 ### Example
+
+In the following example we are binding to a function `map(arr, callback)` and use the `@uncurry` annotation to make sure that `callback` is always treated as an uncurried function:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
@@ -28,6 +28,8 @@ var result = [1, 2, 3].map(function (x) {
 ```
 
 </CodeTab>
+
+As we can see, we defined a regular function `('a) => 'b` instead of `(. 'a) => 'b`, but still have all the guarantees. Please note that the compiler does a lot of optimizations, so the example above will compile to the same code even without the `@uncurry` decorator. Adding the decorator (or using the `(.) =>` syntax) makes the output 100% predictable though.
 
 ### References
 

--- a/misc_docs/syntax/decorator_uncurry.mdx
+++ b/misc_docs/syntax/decorator_uncurry.mdx
@@ -7,8 +7,8 @@ category: "decorators"
 ---
 
 The `@uncurry` decorator allows you to annotate **external** function callback argument types
-so when writing the callbacks they may be declared as normal functions `() => { ... }` rather then needing
-the uncurried function syntax `(.) => { ... }`.
+so when writing the callbacks they may be declared as normal functions `() => { ... }`
+rather than needing the uncurried function syntax `(.) => { ... }`.
 
 ### Example
 

--- a/misc_docs/syntax/decorator_uncurry.mdx
+++ b/misc_docs/syntax/decorator_uncurry.mdx
@@ -1,0 +1,34 @@
+---
+id: "uncurry-decorator"
+keywords: ["uncurry", "decorator"]
+name: "@uncurry"
+summary: "This is the `@uncurry` decorator."
+category: "decorators"
+---
+
+The `@uncurry` decorator allows you to annotate *external* function callback arguments
+so the callbacks may be declared as normal functions `() => { ... }` rather then needing
+the uncurried function syntax `(.) => { ... }`.
+
+### Example
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+@bs.send
+external map: (array<'a>, @uncurry ('a => 'b)) => array<'b> = "map"
+
+let result = map([1, 2, 3], x => x + 1)
+```
+
+```js
+var result = [1, 2, 3].map(function (x) {
+  return (x + 1) | 0
+})
+```
+
+</CodeTab>
+
+### References
+
+- [Curry & Uncurry](/docs/manual/latest/bind-to-js-function#curry--uncurry)


### PR DESCRIPTION
Suggestion for the `@uncurry` decorator syntax page for #162

I've experimented with this one a little, but I haven't yet found it to make any difference. I.e. using the decorator or omitting the decorator had no obvious effect on how the callback is called, or the resulting generated JS code.

I'm guessing the code I've tried so far has not been complex enough to trigger the benefits this decorator brings? Just thought I would mention it.

As usual, happy to receive any feedback on this PR.
