### PR TITLE
Fix typo in docs for named arguments

### DIFF
--- a/pages/docs/manual/latest/function.mdx
+++ b/pages/docs/manual/latest/function.mdx
@@ -124,7 +124,7 @@ You can provide the arguments in **any order**:
 addCoordinates(~y=6, ~x=5)
 ```
 ```js
-addCoordinates(6, 5);
+addCoordinates(5, 6);
 ```
 
 </CodeTab>


### PR DESCRIPTION
The order of arguments in the output was swapped compared to what's correct; that's all.