### PR TITLE
Bump highlight.js to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gentype": "^3.1.0",
     "glob": "^7.1.4",
     "gray-matter": "^4.0.2",
-    "highlight.js": "^9.15.10",
+    "highlight.js": "^10.5.0",
     "lz-string": "^1.4.4",
     "next": "10.0.0",
     "next-transpile-modules": "^2.3.1",

--- a/src/common/App.js
+++ b/src/common/App.js
@@ -24,7 +24,7 @@ import * as BeltDocsLayout8_0_0 from "../layouts/BeltDocsLayout8_0_0.js";
 import * as ApiOverviewLayout8_0_0 from "../layouts/ApiOverviewLayout8_0_0.js";
 import * as ReasonCompilerDocsLayout from "../layouts/ReasonCompilerDocsLayout.js";
 
-let hljs = require('highlight.js/lib/highlight');
+let hljs = require('highlight.js/lib/core');
   let js = require('highlight.js/lib/languages/javascript');
   let ocaml = require('highlight.js/lib/languages/ocaml');
   let reason = require('plugins/reason-highlightjs');

--- a/src/common/App.res
+++ b/src/common/App.res
@@ -7,7 +7,7 @@
 
 // Register all the highlightjs stuff for the whole application
 %%raw(`
-  let hljs = require('highlight.js/lib/highlight');
+  let hljs = require('highlight.js/lib/core');
   let js = require('highlight.js/lib/languages/javascript');
   let ocaml = require('highlight.js/lib/languages/ocaml');
   let reason = require('plugins/reason-highlightjs');

--- a/src/common/HighlightJs.js
+++ b/src/common/HighlightJs.js
@@ -5,7 +5,7 @@ import * as Js_exn from "bs-platform/lib/es6/js_exn.js";
 import * as Belt_Array from "bs-platform/lib/es6/belt_Array.js";
 import * as Caml_option from "bs-platform/lib/es6/caml_option.js";
 import * as Caml_js_exceptions from "bs-platform/lib/es6/caml_js_exceptions.js";
-import * as Highlight from "highlight.js/lib/highlight";
+import * as Core from "highlight.js/lib/core";
 
 function renderHLJS(highlightedLinesOpt, darkmodeOpt, code, lang, param) {
   var highlightedLines = highlightedLinesOpt !== undefined ? highlightedLinesOpt : [];
@@ -14,7 +14,7 @@ function renderHLJS(highlightedLinesOpt, darkmodeOpt, code, lang, param) {
   try {
     match = [
       lang,
-      Highlight.highlight(lang, code).value
+      Core.highlight(lang, code).value
     ];
   }
   catch (raw_exn){

--- a/src/common/HighlightJs.res
+++ b/src/common/HighlightJs.res
@@ -1,7 +1,7 @@
 @bs.deriving(abstract)
 type highlightResult = {value: string}
 
-@bs.module("highlight.js/lib/highlight")
+@bs.module("highlight.js/lib/core")
 external highlight: (~lang: string, ~value: string) => highlightResult = "highlight"
 
 let renderHLJS = (~highlightedLines=[], ~darkmode=false, ~code: string, ~lang: string, ()) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,10 +4106,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.15.10:
-  version "9.18.3"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
-  integrity sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==
+highlight.js@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
+  integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Fixes #188 

I've validated locally, manually spot-checked that all languages referenced did not get renamed in the v10 refactor, and ran tests. Would not mind another pair of eyes, but it looks good to me!