### PR TITLE
Add syntax lookup mod operator

### DIFF
--- a/misc_docs/syntax/operators_mod.mdx
+++ b/misc_docs/syntax/operators_mod.mdx
@@ -1,0 +1,25 @@
+---
+id: "mod"
+keywords: ["mod", "modulo", "operator"]
+name: "mod"
+summary: "This is the `modulo` operator."
+category: "operators"
+---
+
+The `mod` operator calculates the *modulo* (remainder after division) of two integers.
+
+### Example
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+let result = mod(7, 4)
+```
+
+```js
+var result = 3;
+```
+
+</CodeTab>
+
+


### PR DESCRIPTION
It looks like `mod` doesn't support infix syntax at the moment, but presumably it's fine to treat it as an operator for now? What do you think? 