### PR TITLE
Clarify comparison with js

### DIFF
--- a/pages/docs/manual/latest/overview.mdx
+++ b/pages/docs/manual/latest/overview.mdx
@@ -11,20 +11,20 @@ canonical: "/docs/manual/latest/overview"
 
 ### Semicolon
 
-| JavaScript                           | Us                   |
+| JavaScript                           | ReScript             |
 | ------------------------------------ | -------------------- |
 | Rules enforced by linter/formatter   | No semicolon needed! |
 
 ### Comments
 
-| JavaScript        | Us          |
+| JavaScript        | ReScript    |
 | ----------------- | ----------- |
 | `/* Comment */`   | Same        |
 | `// Line comment` | Same        |
 
 ### Variable
 
-| JavaScript              | Us                             |
+| JavaScript              | ReScript                       |
 | ----------------------- | ------------------------------ |
 | `const x = 5;`          | `let x = 5`                    |
 | `var x = y;`            | No equivalent (thankfully)     |
@@ -32,7 +32,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### String & Character
 
-| JavaScript                | Us                    |
+| JavaScript                | ReScript              |
 | --------------------------| --------------------- |
 | `"Hello world!"`          | Same                  |
 | `'Hello world!'`          | Strings must use `"`  |
@@ -41,7 +41,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Boolean
 
-| JavaScript                                            | Us                                             |
+| JavaScript                                            | ReScript                                       |
 | ----------------------------------------------------- | ---------------------------------------------- |
 | `true`, `false`                                       | Same                                           |
 | `!true`                                               | Same                                           |
@@ -52,7 +52,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Number
 
-| JavaScript  | Us           |
+| JavaScript  | ReScript     |
 | ----------- | ------------ |
 | `3`         | Same \*      |
 | `3.1415`    | Same         |
@@ -64,7 +64,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Object/Record
 
-| JavaScript          | Us                                      |
+| JavaScript          | ReScript                                |
 | ------------------- | --------------------------------------- |
 | no types            | `type point = {x: int, mutable y: int}` |
 | `{x: 30, y: 20}`    | Same                                    |
@@ -74,7 +74,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Array
 
-| JavaScript            | Us                                 |
+| JavaScript            | ReScript                           |
 | --------------------- | ---------------------------------- |
 | `[1, 2, 3]`           | Same                               |
 | `myArray[1] = 10`     | Same                               |
@@ -84,7 +84,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Null
 
-| JavaScript          | Us        |
+| JavaScript          | ReScript  |
 | ------------------- | --------- |
 | `null`, `undefined` | `None` \* |
 
@@ -92,7 +92,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Function
 
-| JavaScript                      | Us                           |
+| JavaScript                      | ReScript                     |
 | ------------------------------- | ---------------------------- |
 | `arg => retVal`                 | Same                         |
 | `function named(arg) {...}`     | `let named = (arg) => {...}` |
@@ -130,7 +130,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### If-else
 
-| JavaScript            | Us                                                                  |
+| JavaScript            | ReScript                                                            |
 | --------------------- | ------------------------------------------------------------------- |
 | `if (a) {b} else {c}` | `if a {b} else {c}` \*                                              |
 | `a ? b : c`           | Same                                                                |
@@ -140,7 +140,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Destructuring
 
-| JavaScript                    | Us                                            |
+| JavaScript                    | ReScript                                      |
 | ----------------------------- | --------------------------------------------- |
 | `const {a, b} = data`         | `let {a, b} = data`                           |
 | `const [a, b] = data`         | <code>let [a, b] = data</code> \*             |
@@ -150,7 +150,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Loop
 
-| JavaScript                            | Us                             |
+| JavaScript                            | ReScript                       |
 | ------------------------------------- | ------------------------------ |
 | `for (let i = 0; i <= 10; i++) {...}` | `for i in 0 to 10 {...}`       |
 | `for (let i = 10; i >= 0; i--) {...}` | `for i in 10 downto 0 {...}`   |
@@ -158,7 +158,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### JSX
 
-| JavaScript                                | Us                         |
+| JavaScript                                | ReScript                   |
 | ----------------------------------------- | -------------------------- |
 | `<Comp message="hi" onClick={handler} />` | Same                       |
 | `<Comp message={message} />`              | `<Comp message />` \*      |
@@ -169,7 +169,7 @@ canonical: "/docs/manual/latest/overview"
 
 ### Exception
 
-| JavaScript                                      | Us                                         |
+| JavaScript                                      | ReScript                                   |
 | ----------------------------------------------- | ------------------------------------------ |
 | `throw new SomeError(...)`                      | `raise(SomeError(...))`                    |
 | `try {a} catch (Err) {...} finally {...}`       | <code>try a catch { &#124; Err => ...}</code> \* |


### PR DESCRIPTION
Replace 'us' with ReScript as looks nicer and more intuitive and cannot be confused with the US which it did for me because it's rendered in caps on the website.