### PR TITLE
[docs/react] Fix keys and arrays example

### DIFF
--- a/pages/docs/react/latest/arrays-and-keys.mdx
+++ b/pages/docs/react/latest/arrays-and-keys.mdx
@@ -41,10 +41,10 @@ let items = Belt.Array.map(todos, todo => {
 
 If you don’t have stable IDs for rendered items, you may use the item index as a key as a last resort:
 
-```res {2,3}
-let items = Belt.Array.mapWithIndex(todos, (todo, i) => {
+```res {1..3}
+let items = Belt.Array.mapWithIndex(todos, (i, todo) => {
   // Only do this if items have no stable id
-  <li key={i}>
+  <li key={Belt.Int.toString(i)}>
     {todo.text}
   </li>
 });


### PR DESCRIPTION
Fixes #224

#### Changes
* Reverse parameters  of the `Belt.Array.mapWithIndex` call
* Convert index `i` to string
* Also highlight the first line of the example (as a newcomer to rescript you're likely to ignore that you need a different function to access index within a map call).

#### Before
<img width="666" alt="Capture d’écran 2021-02-17 à 00 28 10" src="https://user-images.githubusercontent.com/14045559/108136326-2ad8a080-70ba-11eb-8940-dcf50ecb521d.png">

#### After
<img width="671" alt="Capture d’écran 2021-02-17 à 00 27 59" src="https://user-images.githubusercontent.com/14045559/108136340-2f9d5480-70ba-11eb-9c61-e48a782d6483.png">
